### PR TITLE
Allow component props to be updated

### DIFF
--- a/.github/workflows/formatbot.yml
+++ b/.github/workflows/formatbot.yml
@@ -31,6 +31,12 @@ jobs:
     - name: Run formatter
       run: npx @biomejs/biome check --write --unsafe .
 
+    - name: Restore lock files
+      run: |
+        git checkout -- *lock.json || true
+        git checkout -- *.lock || true
+        git checkout -- *.lockb || true
+
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/examples/jscad-three-mesh.fixture.tsx
+++ b/examples/jscad-three-mesh.fixture.tsx
@@ -1,20 +1,39 @@
 import { OrbitControls } from "@react-three/drei"
 import { Canvas } from "@react-three/fiber"
-import { Cube } from "../lib"
+import { Custom } from "../lib"
 import { JSCadThreeMesh } from "../lib/components/jscad-three-mesh"
+import { useState } from "react"
+import { cube, sphere } from "@jscad/modeling/src/primitives"
 
-export default () => (
-  <div
+export default () => {
+
+  const [solid, setSolid] = useState(cube({ size: 10 }));
+
+  const setCube = () => {
+    setSolid(cube({ size: 10 }));
+  }
+
+  const setSphere = () => {
+    setSolid(sphere({ radius: 6, segments: 32 }));
+  }
+
+  return (
+    <div
     style={{
       width: "100%",
       height: "100vh",
     }}
   >
+    <button onClick={setCube} type="button">Cube</button>
+    <button onClick={setSphere} type="button">Sphere</button>
     <Canvas>
       <JSCadThreeMesh>
-        <Cube size={10} />
+        <Custom geometry={solid} />
       </JSCadThreeMesh>
       <OrbitControls />
     </Canvas>
   </div>
-)
+  )
+
+ 
+}

--- a/examples/jscad-three-mesh.fixture.tsx
+++ b/examples/jscad-three-mesh.fixture.tsx
@@ -1,39 +1,40 @@
+import { cube, sphere } from "@jscad/modeling/src/primitives"
 import { OrbitControls } from "@react-three/drei"
 import { Canvas } from "@react-three/fiber"
+import { useState } from "react"
 import { Custom } from "../lib"
 import { JSCadThreeMesh } from "../lib/components/jscad-three-mesh"
-import { useState } from "react"
-import { cube, sphere } from "@jscad/modeling/src/primitives"
 
 export default () => {
-
-  const [solid, setSolid] = useState(cube({ size: 10 }));
+  const [solid, setSolid] = useState(cube({ size: 10 }))
 
   const setCube = () => {
-    setSolid(cube({ size: 10 }));
+    setSolid(cube({ size: 10 }))
   }
 
   const setSphere = () => {
-    setSolid(sphere({ radius: 6, segments: 32 }));
+    setSolid(sphere({ radius: 6, segments: 32 }))
   }
 
   return (
     <div
-    style={{
-      width: "100%",
-      height: "100vh",
-    }}
-  >
-    <button onClick={setCube} type="button">Cube</button>
-    <button onClick={setSphere} type="button">Sphere</button>
-    <Canvas>
-      <JSCadThreeMesh>
-        <Custom geometry={solid} />
-      </JSCadThreeMesh>
-      <OrbitControls />
-    </Canvas>
-  </div>
+      style={{
+        width: "100%",
+        height: "100vh",
+      }}
+    >
+      <button onClick={setCube} type="button">
+        Cube
+      </button>
+      <button onClick={setSphere} type="button">
+        Sphere
+      </button>
+      <Canvas>
+        <JSCadThreeMesh>
+          <Custom geometry={solid} />
+        </JSCadThreeMesh>
+        <OrbitControls />
+      </Canvas>
+    </div>
   )
-
- 
 }

--- a/lib/create-host-config.ts
+++ b/lib/create-host-config.ts
@@ -327,7 +327,15 @@ export function createHostConfig(jscad: JSCADModule) {
       newProps: any,
     ) {
       // Re-create the instance with new props
-      return createInstance(type, newProps, instance, {}, null)
+      const newInstance = createInstance(type, newProps, instance, {}, null)
+
+      // Clear properties of the old instance
+      for (const key in instance) {
+        delete instance[key]
+      }
+
+      // Assign new properties to the old instance
+      Object.assign(instance, newInstance)
     },
 
     finalizeInitialChildren() {


### PR DESCRIPTION
Fixes the `commitUpdate` function in `create-host-config` to allow components to be updated.

This function wants the passed `instance` variable to be mutated rarther than a new instance to be returned (see: https://github.com/facebook/react/blob/main/packages/react-reconciler/README.md#commitupdateinstance-type-prevprops-nextprops-internalhandle).

Also changes the `jscad-three-mesh.fixture.tsx` to verify that the changes work