### PR TITLE
Show code examples on usage site 

### DIFF
--- a/examples/array-based-subtraction.fixture.tsx
+++ b/examples/array-based-subtraction.fixture.tsx
@@ -1,7 +1,10 @@
+import Example from "src/Example"
+import { designCodeArray } from "src/designCode"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
-import { Colorize, Cuboid, Sphere, Subtract } from "../lib/jscad-fns"
+import { Cuboid, Subtract } from "../lib/jscad-fns"
 
 export default () => (
+  <Example designCode={designCodeArray}>
   <JsCadFixture zAxisUp showGrid>
     <Subtract>
       <Cuboid size={[10, 5, 2]} />
@@ -10,4 +13,5 @@ export default () => (
       ))}
     </Subtract>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/circle.fixture.tsx
+++ b/examples/circle.fixture.tsx
@@ -1,8 +1,13 @@
-import { Circle } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCircle } from "src/designCode";
+import Example from "src/Example";
+import { Circle } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
+
 
 export default () => (
+  <Example designCode={designCodeCircle}>
   <JsCadFixture>
     <Circle radius={10} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/colorize.fixture.tsx
+++ b/examples/colorize.fixture.tsx
@@ -1,10 +1,14 @@
+import Example from "src/Example"
+import { designCodeColorizeCube } from "src/designCode"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 import { Colorize, Cube } from "../lib/jscad-fns"
 
 export default () => (
+  <Example designCode={designCodeColorizeCube}>
   <JsCadFixture>
     <Colorize color={"red"}>
       <Cube size={10} />
     </Colorize>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/cone.fixture.tsx
+++ b/examples/cone.fixture.tsx
@@ -1,7 +1,10 @@
-import { CylinderElliptic } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCone } from "src/designCode";
+import Example from "src/Example";
+import { CylinderElliptic } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCone}>
   <JsCadFixture wireframe>
     <CylinderElliptic
       height={5}
@@ -14,4 +17,5 @@ export default () => (
       center={[0, 5, 5]}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/cube.fixture.tsx
+++ b/examples/cube.fixture.tsx
@@ -1,8 +1,12 @@
-import { Cube } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCube } from "src/designCode";
+import Example from "src/Example";
+import { Cube } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCube}>
   <JsCadFixture>
     <Cube size={10} color="orange" center={[0, 0, 10]} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/cuboid.fixture.tsx
+++ b/examples/cuboid.fixture.tsx
@@ -1,8 +1,12 @@
-import { Cuboid } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCuboid } from "src/designCode";
+import Example from "src/Example";
+import { Cuboid } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCuboid}>
   <JsCadFixture zAxisUp showGrid>
     <Cuboid color="blue" offset={{ x: 0, y: 0, z: 0 }} size={[15, 10, 10]} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/custom-sphere.fixture.tsx
+++ b/examples/custom-sphere.fixture.tsx
@@ -1,8 +1,12 @@
-import { Sphere } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCustomSphere } from "src/designCode";
+import Example from "src/Example";
+import { Sphere } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCustomSphere}>
   <JsCadFixture wireframe>
     <Sphere radius={10} segments={64} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/custom-torus.fixture.tsx
+++ b/examples/custom-torus.fixture.tsx
@@ -1,7 +1,10 @@
-import { Torus } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCustomTorus } from "src/designCode";
+import Example from "src/Example";
+import { Torus } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCustomTorus}>
   <JsCadFixture wireframe>
     <Torus
       innerRadius={15}
@@ -13,4 +16,5 @@ export default () => (
       startAngle={0}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/custom.fixture.tsx
+++ b/examples/custom.fixture.tsx
@@ -1,6 +1,8 @@
-import { booleans, primitives } from "@jscad/modeling"
-import { Custom } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { booleans, primitives } from "@jscad/modeling";
+import { designCodeCustom } from "src/designCode";
+import Example from "src/Example";
+import { Custom } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 const cube = primitives.cube({ size: 10 })
 const sphere = primitives.sphere({ radius: 6, segments: 32 })
@@ -8,7 +10,9 @@ const sphere = primitives.sphere({ radius: 6, segments: 32 })
 const intersected = booleans.subtract(cube, sphere)
 
 export default () => (
+    <Example designCode={designCodeCustom}>
   <JsCadFixture>
     <Custom geometry={intersected} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/cylinder.fixture.tsx
+++ b/examples/cylinder.fixture.tsx
@@ -1,7 +1,10 @@
-import { Cylinder } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeCylinder } from "src/designCode";
+import Example from "src/Example";
+import { Cylinder } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeCylinder}>
   <JsCadFixture showGrid zAxisUp>
     <Cylinder
       radius={5}
@@ -12,4 +15,5 @@ export default () => (
     />
     <Cylinder radius={5} height={10} color="#F7E8AA" center={[20, 0, 0]} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/ellipsoid.fixture.tsx
+++ b/examples/ellipsoid.fixture.tsx
@@ -1,8 +1,12 @@
-import { Ellipsoid } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeEllipsoid } from "src/designCode";
+import Example from "src/Example";
+import { Ellipsoid } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
+  <Example designCode={designCodeEllipsoid}>
   <JsCadFixture wireframe>
     <Ellipsoid radius={[15, 10, 10]} color="brown" center={[0, 0, 10]} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/extrude-from-slices.fixture.tsx
+++ b/examples/extrude-from-slices.fixture.tsx
@@ -1,6 +1,8 @@
-import { ExtrudeFromSlices } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
-import jscad from "@jscad/modeling"
+import jscad from "@jscad/modeling";
+import { designCodeExtrudeFromSlices } from "src/designCode";
+import Example from "src/Example";
+import { ExtrudeFromSlices } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 const { bezier } = jscad.curves
 const { circle, line, polygon, rectangle, roundedRectangle, star } =
@@ -20,6 +22,7 @@ const xCurve = bezier.create([1, 1.8, 0.4, 1])
 const yCurve = bezier.create([1, 1.8, 0.5])
 
 export default () => (
+  <Example designCode={designCodeExtrudeFromSlices}>
   <JsCadFixture zAxisUp showGrid>
     <ExtrudeFromSlices
       numberOfSlices={10}
@@ -53,4 +56,5 @@ export default () => (
       }}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/extrude-linear.fixture.tsx
+++ b/examples/extrude-linear.fixture.tsx
@@ -1,8 +1,12 @@
-import { JsCadFixture } from "../lib/components/jscad-fixture"
-import { ExtrudeLinear } from "../lib/jscad-fns"
-import { Polygon } from "../lib/jscad-fns/polygon"
+import { designCodeExtrudeLinear } from "src/designCode";
+import Example from "src/Example";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
+import { ExtrudeLinear } from "../lib/jscad-fns";
+import { Polygon } from "../lib/jscad-fns/polygon";
 
 export default () => (
+    <Example designCode={designCodeExtrudeLinear}>
+
   <JsCadFixture>
     <ExtrudeLinear height={2} color="lightgreen" center={[0, 0, 4]}>
       <Polygon
@@ -18,4 +22,5 @@ export default () => (
       />
     </ExtrudeLinear>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/extrude-rectangular.fixture.tsx
+++ b/examples/extrude-rectangular.fixture.tsx
@@ -1,8 +1,11 @@
+import { designCodeExtrudeRectangular } from "src/designCode"
+import Example from "src/Example"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 import { ExtrudeRectangular } from "../lib/jscad-fns"
 import { Polygon } from "../lib/jscad-fns/polygon"
 
 export default () => (
+  <Example designCode={designCodeExtrudeRectangular}>
   <JsCadFixture>
     <ExtrudeRectangular
       size={10}
@@ -23,4 +26,5 @@ export default () => (
       />
     </ExtrudeRectangular>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/high-geodesic-sphere.fixture.tsx
+++ b/examples/high-geodesic-sphere.fixture.tsx
@@ -1,7 +1,10 @@
+import { designCodeHighGeodesicsphere } from "src/designCode"
+import Example from "src/Example"
 import { GeodesicSphere } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+<Example designCode={designCodeHighGeodesicsphere}>
   <JsCadFixture wireframe>
     <GeodesicSphere
       radius={10}
@@ -10,4 +13,5 @@ export default () => (
       center={[10, 5, 0]}
     />
   </JsCadFixture>
+</Example>
 )

--- a/examples/hull-chain.fixture.tsx
+++ b/examples/hull-chain.fixture.tsx
@@ -1,7 +1,10 @@
+import { designCodeHullChain } from "src/designCode"
+import Example from "src/Example"
 import { Cuboid, Ellipsoid, HullChain } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+  <Example designCode={designCodeHullChain}>
   <JsCadFixture>
     <HullChain color="lightgreen" center={[0, 0, -10]}>
       <Cuboid size={[10, 10, 10]} />
@@ -9,4 +12,5 @@ export default () => (
       <Cuboid size={[10, 10, 10]} center={[0, 0, 20]} />
     </HullChain>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/hull.fixture.tsx
+++ b/examples/hull.fixture.tsx
@@ -1,11 +1,15 @@
-import { Cuboid, Ellipsoid, Hull, Translate } from "../lib"
+import { designCodeHull } from "src/designCode"
+import Example from "src/Example"
+import { Cuboid, Ellipsoid, Hull } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+  <Example designCode={designCodeHull}>
   <JsCadFixture>
     <Hull color="lightblue" center={[0, -5, -10]}>
       <Cuboid size={[10, 10, 10]} />
       <Ellipsoid radius={[10, 10, 10]} center={[0, 0, 15]} />
     </Hull>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/low-geodesic-sphere.fixture.tsx
+++ b/examples/low-geodesic-sphere.fixture.tsx
@@ -1,8 +1,12 @@
+import { designCodeGeodesicSphere } from "src/designCode"
+import Example from "src/Example"
 import { GeodesicSphere } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+  <Example designCode={designCodeGeodesicSphere}>
   <JsCadFixture wireframe>
     <GeodesicSphere radius={10} frequency={6} />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/partial-cylindrical-elliptic.fixture.tsx
+++ b/examples/partial-cylindrical-elliptic.fixture.tsx
@@ -1,8 +1,11 @@
+import { designCodeCylinderElliptic } from "src/designCode"
+import Example from "src/Example"
 import { CylinderElliptic } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
-  <JsCadFixture wireframe>
+<Example designCode={designCodeCylinderElliptic}>
+ <JsCadFixture wireframe>
     <CylinderElliptic
       height={6}
       startRadius={[1, 2]}
@@ -12,4 +15,5 @@ export default () => (
       endAngle={Math.PI / 2}
     />
   </JsCadFixture>
+</Example>
 )

--- a/examples/polygon.fixture.tsx
+++ b/examples/polygon.fixture.tsx
@@ -1,7 +1,10 @@
+import { designCodePolygon } from "src/designCode"
+import Example from "src/Example"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 import { Polygon } from "../lib/jscad-fns/polygon"
 
 export default () => (
+  <Example designCode={designCodePolygon}>
   <JsCadFixture>
     <Polygon
       points={[
@@ -15,4 +18,5 @@ export default () => (
       ]}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/project.fixture.tsx
+++ b/examples/project.fixture.tsx
@@ -1,8 +1,11 @@
+import { designCodeProject } from "src/designCode"
+import Example from "src/Example"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 import { Project } from "../lib/jscad-fns"
 import { Polygon } from "../lib/jscad-fns/polygon"
 
 export default () => (
+    <Example designCode={designCodeProject}>
   <JsCadFixture>
     <Project axis={[0, 0, 1]} origin={[0, 0, 0]}>
       <Polygon
@@ -18,4 +21,5 @@ export default () => (
       />
     </Project>
   </JsCadFixture>
+  </Example>
 )

--- a/examples/rectangle.fixture.tsx
+++ b/examples/rectangle.fixture.tsx
@@ -1,8 +1,13 @@
+import { designCodeRectangle } from "src/designCode"
+import Example from "src/Example"
 import { Rectangle } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
+
 export default () => (
+    <Example designCode={designCodeRectangle}>
   <JsCadFixture>
     <Rectangle size={[10, 20]} />
   </JsCadFixture>
+</Example>
 )

--- a/examples/rotate.fixture.tsx
+++ b/examples/rotate.fixture.tsx
@@ -1,8 +1,11 @@
+import { designCodeRotate } from "src/designCode"
+import Example from "src/Example"
 import { Polygon } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 import { Rotate } from "../lib/jscad-fns"
 
 export default () => (
+    <Example designCode={designCodeRotate}>
   <JsCadFixture>
     <Rotate angles={[0, 0, Math.PI]} color="cyan" center={[0, 0, 10]}>
       <Polygon
@@ -18,4 +21,5 @@ export default () => (
       />
     </Rotate>
   </JsCadFixture>
+</Example>
 )

--- a/examples/rounded-cuboid.fixture.tsx
+++ b/examples/rounded-cuboid.fixture.tsx
@@ -1,7 +1,10 @@
+import { designCodeRoundedCuboid } from "src/designCode"
+import Example from "src/Example"
 import { RoundedCuboid } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+  <Example designCode={designCodeRoundedCuboid}>
   <JsCadFixture>
     <RoundedCuboid
       size={[15, 10, 10]}
@@ -10,4 +13,5 @@ export default () => (
       center={[0, 0, 10]}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/rounded-cylinder.fixture.tsx
+++ b/examples/rounded-cylinder.fixture.tsx
@@ -1,7 +1,10 @@
+import { designCodeRoundedCylinder } from "src/designCode"
+import Example from "src/Example"
 import { RoundedCylinder } from "../lib"
 import { JsCadFixture } from "../lib/components/jscad-fixture"
 
 export default () => (
+    <Example designCode={designCodeRoundedCylinder}>
   <JsCadFixture wireframe>
     <RoundedCylinder
       radius={10}
@@ -11,4 +14,5 @@ export default () => (
       center={[0, 0, 10]}
     />
   </JsCadFixture>
+  </Example>
 )

--- a/examples/sphere.fixture.tsx
+++ b/examples/sphere.fixture.tsx
@@ -1,8 +1,12 @@
-import { Sphere } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeSphere } from "src/designCode";
+import Example from "src/Example";
+import { Sphere } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
-  <JsCadFixture wireframe>
-    <Sphere radius={10} color="orange" />
-  </JsCadFixture>
-)
+  <Example designCode={designCodeSphere}>
+    <JsCadFixture wireframe>
+      <Sphere radius={10} color="orange" />
+    </JsCadFixture>
+  </Example>
+);

--- a/examples/subtract.fixture.tsx
+++ b/examples/subtract.fixture.tsx
@@ -1,11 +1,15 @@
-import { Cube, Sphere, Subtract } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeSubtract } from "src/designCode";
+import Example from "src/Example";
+import { Cube, Sphere, Subtract } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
-  <JsCadFixture>
-    <Subtract>
-      <Cube size={10} />
-      <Sphere radius={6} />
-    </Subtract>
-  </JsCadFixture>
-)
+  <Example designCode={designCodeSubtract}>
+    <JsCadFixture>
+      <Subtract>
+        <Cube size={10} />
+        <Sphere radius={6} />
+      </Subtract>
+    </JsCadFixture>
+  </Example>
+);

--- a/examples/torus.fixture.tsx
+++ b/examples/torus.fixture.tsx
@@ -1,8 +1,17 @@
-import { Torus } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeTorus } from "src/designCode";
+import Example from "src/Example";
+import { Torus } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
-  <JsCadFixture wireframe>
-    <Torus innerRadius={1} outerRadius={1.2} color="red" center={[0, 10, 0]} />
-  </JsCadFixture>
-)
+  <Example designCode={designCodeTorus}>
+    <JsCadFixture wireframe>
+      <Torus
+        innerRadius={1}
+        outerRadius={1.2}
+        color="red"
+        center={[0, 10, 0]}
+      />
+    </JsCadFixture>
+  </Example>
+);

--- a/examples/translate.fixture.tsx
+++ b/examples/translate.fixture.tsx
@@ -1,26 +1,30 @@
-import { Cuboid } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
-import { Translate } from "../lib/jscad-fns"
+import { designCodeTranslate } from "src/designCode";
+import Example from "src/Example";
+import { Cuboid } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
+import { Translate } from "../lib/jscad-fns";
 
 export default () => (
-  <JsCadFixture>
-    <Cuboid size={[20, 10, 10]} />
-    <Cuboid center={[0, 0, 15]} size={[15, 10, 15]} color="red" />
-    <Translate offset={[0, 0, -15]}>
-      <Cuboid size={[15, 10, 15]} color="blue" />
-      <Cuboid size={[5, 25, 5]} color="white" />
-    </Translate>
-    <Translate offset={[0, 15, 0]}>
+  <Example designCode={designCodeTranslate}>
+    <JsCadFixture>
+      <Cuboid size={[20, 10, 10]} />
+      <Cuboid center={[0, 0, 15]} size={[15, 10, 15]} color="red" />
       <Translate offset={[0, 0, -15]}>
-        <Cuboid size={[3, 3, 3]} color="green" />
-        <Cuboid size={[4, 2, 4]} color="white" />
-        <Cuboid size={[5, 1, 5]} color="red" />
-        <Translate offset={[0, 0, -10]}>
-          <Cuboid size={[3, 3, 3]} color="blue" />
+        <Cuboid size={[15, 10, 15]} color="blue" />
+        <Cuboid size={[5, 25, 5]} color="white" />
+      </Translate>
+      <Translate offset={[0, 15, 0]}>
+        <Translate offset={[0, 0, -15]}>
+          <Cuboid size={[3, 3, 3]} color="green" />
           <Cuboid size={[4, 2, 4]} color="white" />
           <Cuboid size={[5, 1, 5]} color="red" />
+          <Translate offset={[0, 0, -10]}>
+            <Cuboid size={[3, 3, 3]} color="blue" />
+            <Cuboid size={[4, 2, 4]} color="white" />
+            <Cuboid size={[5, 1, 5]} color="red" />
+          </Translate>
         </Translate>
       </Translate>
-    </Translate>
-  </JsCadFixture>
-)
+    </JsCadFixture>
+  </Example>
+);

--- a/examples/twisted-cylindrical-elliptic.fixture.tsx
+++ b/examples/twisted-cylindrical-elliptic.fixture.tsx
@@ -1,15 +1,19 @@
-import { CylinderElliptic } from "../lib"
-import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { designCodeTwistedCylinderElliptic } from "src/designCode";
+import Example from "src/Example";
+import { CylinderElliptic } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
 
 export default () => (
-  <JsCadFixture wireframe>
-    <CylinderElliptic
-      height={6}
-      startRadius={[1, 1.5]}
-      endRadius={[1.5, 1]}
-      segments={64}
-      startAngle={0}
-      endAngle={Math.PI * 2}
-    />
-  </JsCadFixture>
-)
+  <Example designCode={designCodeTwistedCylinderElliptic}>
+    <JsCadFixture wireframe>
+      <CylinderElliptic
+        height={6}
+        startRadius={[1, 1.5]}
+        endRadius={[1.5, 1]}
+        segments={64}
+        startAngle={0}
+        endAngle={Math.PI * 2}
+      />
+    </JsCadFixture>
+  </Example>
+);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "dependencies": {
     "color": "^4.2.3",
-    "react-reconciler": "^0.29.2"
+    "react-icons": "^5.3.0",
+    "react-reconciler": "^0.29.2",
+    "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",

--- a/src/CodeViewer.tsx
+++ b/src/CodeViewer.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { FiCopy } from "react-icons/fi";
+import { LightAsync as SyntaxHighlighter } from "react-syntax-highlighter";
+import { vs2015 } from "react-syntax-highlighter/dist/esm/styles/hljs";
+
+interface CodeViewerProps {
+  code: string;
+}
+
+const CodeViewer: React.FC<CodeViewerProps> = ({ code }) => {
+  const [copySuccess, setCopySuccess] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy code: ", err);
+    }
+  };
+
+  return (
+    <div style={{ position: "relative", width: "100%" }}>
+      <SyntaxHighlighter
+        language="typescript"
+        style={vs2015}
+        showLineNumbers
+        customStyle={{
+          padding: "16px",
+          borderRadius: "8px",
+          backgroundColor: "black",
+          overflow: "auto",
+        }}
+      >
+        {code}
+      </SyntaxHighlighter>
+
+      {/* Copy button outside the SyntaxHighlighter, but within the container */}
+      <button
+        onClick={handleCopy}
+        style={{
+          position: "absolute",
+          top: "8px",
+          right: "8px",
+          backgroundColor: "transparent",
+          border: "none",
+          color: "white",
+          cursor: "pointer",
+          zIndex: 10,
+        }}
+        title="Copy to clipboard"
+      >
+        <FiCopy size={20} />
+      </button>
+
+      {/* Optional message to show copy success */}
+      {copySuccess && (
+        <span
+          style={{
+            position: "absolute",
+            top: "40px",
+            right: "8px",
+            color: "white",
+            fontSize: "0.9rem",
+          }}
+        >
+          Copied!
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default CodeViewer;

--- a/src/Example.tsx
+++ b/src/Example.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import CodeViewer from './CodeViewer';
+import './main.css';
+
+interface ExampleProps {
+  designCode: string;
+  children: React.ReactNode;
+}
+
+const Example: React.FC<ExampleProps> = ({ designCode, children }) => {
+  const [showCode, setShowCode] = useState(false);
+
+  const handleToggleCode = () => {
+    setShowCode(!showCode);
+    console.log('showCode is now:', !showCode); // Debugging line
+  };
+
+  return (
+    <div className="example-container">
+      {children}
+
+      {/* Button to toggle code visibility */}
+      <button onClick={handleToggleCode} className="toggle-button">
+        {showCode ? 'Hide Code' : 'View Code'}
+      </button>
+
+      {/* Conditionally render the CodeViewer */}
+      {showCode && (
+        <div className="code-viewer">
+          <CodeViewer code={designCode} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Example;

--- a/src/designCode.ts
+++ b/src/designCode.ts
@@ -1,0 +1,630 @@
+// src/code/designCode.ts
+
+export const designCodeArray = `
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { Colorize, Cuboid, Sphere, Subtract } from "../lib/jscad-fns"
+
+export default () => (
+  <JsCadFixture zAxisUp showGrid>
+    <Subtract>
+      <Cuboid size={[10, 5, 2]} />
+      {[-4, -2, 0, 2, 4].map((value, index) => (
+        <Cuboid key={index} center={[value, 0, 0]} size={[1, 1, 4]} />
+      ))}
+    </Subtract>
+  </JsCadFixture>
+);
+`;
+
+
+
+// Circle design code
+export const designCodeCircle = `
+import { Circle } from "../lib";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
+
+export default () => (
+  <JsCadFixture>
+    <Circle radius={10} />
+  </JsCadFixture>
+);
+`;
+
+
+export const designCodeColorizeCube = `
+import { Colorize, Cube } from "../lib/jscad-fns";
+import { JsCadFixture } from "../lib/components/jscad-fixture";
+
+export default () => (
+  <JsCadFixture>
+    <Colorize color={"red"}>
+      <Cube size={10} />
+    </Colorize>
+  </JsCadFixture>
+);
+`;
+
+//cone
+export const designCodeCone = `
+import { CylinderElliptic } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <CylinderElliptic
+      height={5}
+      startRadius={[2, 2]}
+      endRadius={[0, 0]}
+      segments={32}
+      startAngle={0}
+      endAngle={Math.PI * 2}
+      color="green"
+      center={[0, 5, 5]}
+    />
+  </JsCadFixture>
+);
+`;
+
+
+//cube
+
+export const designCodeCube = `
+import { Cube } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <Cube size={10} color="orange" center={[0, 0, 10]} />
+  </JsCadFixture>
+);
+`;
+
+//cuboid
+
+export const designCodeCuboid = `
+import { Cuboid } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture zAxisUp showGrid>
+    <Cuboid color="blue" offset={{ x: 0, y: 0, z: 0 }} size={[15, 10, 10]} />
+  </JsCadFixture>
+);
+`;
+
+//custom
+
+export const designCodeCustom = `
+import { booleans, primitives } from "@jscad/modeling"
+import { Custom } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+const cube = primitives.cube({ size: 10 })
+const sphere = primitives.sphere({ radius: 6, segments: 32 })
+
+const intersected = booleans.subtract(cube, sphere)
+
+export default () => (
+  <JsCadFixture>
+    <Custom geometry={intersected} />
+  </JsCadFixture>
+)
+
+;
+`;
+
+
+//custom-sphere
+
+export const designCodeCustomSphere = `
+import { Sphere } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <Sphere radius={10} segments={64} />
+  </JsCadFixture>
+)
+;
+`;
+
+//custom-torus
+
+export const designCodeCustomTorus = `
+import { Torus } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <Torus
+      innerRadius={15}
+      outerRadius={20}
+      innerSegments={64}
+      outerSegments={96}
+      innerRotation={Math.PI}
+      outerRotation={Math.PI / 2}
+      startAngle={0}
+    />
+  </JsCadFixture>
+)
+;
+`;
+
+
+//cylinder
+
+export const designCodeCylinder = `
+import { Cylinder } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture showGrid zAxisUp>
+    <Cylinder
+      radius={5}
+      height={10}
+      color="#F7E8AA"
+      center={[-20, 0, 0]}
+      rotation={["90deg", 0, 0]}
+    />
+    <Cylinder radius={5} height={10} color="#F7E8AA" center={[20, 0, 0]} />
+  </JsCadFixture>
+);
+`;
+
+//ellipsoid
+
+export const designCodeEllipsoid = `
+import { Ellipsoid } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <Ellipsoid radius={[15, 10, 10]} color="brown" center={[0, 0, 10]} />
+  </JsCadFixture>
+);
+`;
+
+//ExtrudeFromSlices
+
+export const designCodeExtrudeFromSlices = `
+import { ExtrudeFromSlices } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import jscad from "@jscad/modeling"
+
+const { bezier } = jscad.curves
+const { circle, line, polygon, rectangle, roundedRectangle, star } =
+  jscad.primitives
+const { extrudeLinear, extrudeRotate, extrudeFromSlices, slice } =
+  jscad.extrusions
+const { mat4 } = jscad.maths
+
+const baseSlice = slice.fromPoints([
+  [2, 2],
+  [-2, 2],
+  [-2, -2],
+  [2, -2],
+])
+
+const xCurve = bezier.create([1, 1.8, 0.4, 1])
+const yCurve = bezier.create([1, 1.8, 0.5])
+
+export default () => (
+  <JsCadFixture zAxisUp showGrid>
+    <ExtrudeFromSlices
+      numberOfSlices={10}
+      capStart={true}
+      capEnd={true}
+      close={true}
+      repair={true}
+      baseSlice={baseSlice}
+      callback={function (progress, count, base) {
+        let newslice = slice.transform(
+          mat4.fromTranslation(mat4.create(), [0, 0, 10 * progress]),
+          baseSlice,
+        )
+        newslice = slice.transform(
+          mat4.fromScaling(mat4.create(), [
+            bezier.valueAt(progress, xCurve) as any,
+            bezier.valueAt(progress, yCurve) as any,
+            1,
+          ]),
+          newslice,
+        )
+
+        // Rotate the slice 90 degrees along the path
+        const rotationAngle = (Math.PI / 2) * progress // 90 degrees in radians
+        newslice = slice.transform(
+          mat4.fromXRotation(mat4.create(), rotationAngle),
+          newslice,
+        )
+
+        return newslice
+      }}
+    />
+  </JsCadFixture>
+);
+`;
+
+//extrude-helical
+
+//add code here
+
+
+//extrude-linear
+
+export const designCodeExtrudeLinear = `
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { ExtrudeLinear } from "../lib/jscad-fns"
+import { Polygon } from "../lib/jscad-fns/polygon"
+
+export default () => (
+  <JsCadFixture>
+    <ExtrudeLinear height={2} color="lightgreen" center={[0, 0, 4]}>
+      <Polygon
+        points={[
+          [-2, -1],
+          [2, -1],
+          [2.5, 2],
+          [1, 1],
+          [0, 2],
+          [-1, 1],
+          [-2, 2],
+        ]}
+      />
+    </ExtrudeLinear>
+  </JsCadFixture>
+)
+;
+`;
+
+//ExtrudeRectangular
+
+export const designCodeExtrudeRectangular = `
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { ExtrudeRectangular } from "../lib/jscad-fns"
+import { Polygon } from "../lib/jscad-fns/polygon"
+
+export default () => (
+  <JsCadFixture>
+    <ExtrudeRectangular
+      size={10}
+      height={2}
+      color="lightgreen"
+      center={[0, -10, 0]}
+    >
+      <Polygon
+        points={[
+          [-2, -1],
+          [2, -1],
+          [2.5, 2],
+          [1, 1],
+          [0, 2],
+          [-1, 1],
+          [-2, 2],
+        ]}
+      />
+    </ExtrudeRectangular>
+  </JsCadFixture>
+)
+
+;
+`;
+
+//ExtrudeRotate
+
+//code here
+
+
+//HighGeodesicsphere
+
+export const designCodeHighGeodesicsphere = `
+import { GeodesicSphere } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <GeodesicSphere
+      radius={10}
+      frequency={12}
+      color="violet"
+      center={[10, 5, 0]}
+    />
+  </JsCadFixture>
+)
+;
+`;
+
+// hull
+
+export const designCodeHull = `
+import { Cuboid, Ellipsoid, Hull, Translate } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <Hull color="lightblue" center={[0, -5, -10]}>
+      <Cuboid size={[10, 10, 10]} />
+      <Ellipsoid radius={[10, 10, 10]} center={[0, 0, 15]} />
+    </Hull>
+  </JsCadFixture>
+)
+;
+`;
+
+
+//hull-chain
+
+export const designCodeHullChain = `
+import { Cuboid, Ellipsoid, HullChain } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <HullChain color="lightgreen" center={[0, 0, -10]}>
+      <Cuboid size={[10, 10, 10]} />
+      <Ellipsoid radius={[10, 10, 12]} center={[0, 0, 10]} />
+      <Cuboid size={[10, 10, 10]} center={[0, 0, 20]} />
+    </HullChain>
+  </JsCadFixture>
+)
+
+;
+`;
+
+//GeodesicSphere
+
+export const designCodeGeodesicSphere = `
+import { GeodesicSphere } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <GeodesicSphere radius={10} frequency={6} />
+  </JsCadFixture>
+);
+`;
+
+//CylinderElliptic
+
+export const designCodeCylinderElliptic = `
+import { CylinderElliptic } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <CylinderElliptic
+      height={6}
+      startRadius={[1, 2]}
+      endRadius={[1, 2]}
+      segments={64}
+      startAngle={0}
+      endAngle={Math.PI / 2}
+    />
+  </JsCadFixture>
+)
+;
+`;
+
+//polygon
+
+export const designCodePolygon = `
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { Polygon } from "../lib/jscad-fns/polygon"
+
+export default () => (
+  <JsCadFixture>
+    <Polygon
+      points={[
+        [-2, -1],
+        [2, -1],
+        [2.5, 2],
+        [1, 1],
+        [0, 2],
+        [-1, 1],
+        [-2, 2],
+      ]}
+    />
+  </JsCadFixture>
+)
+;
+`;
+
+//project
+
+export const designCodeProject = `
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { Project } from "../lib/jscad-fns"
+import { Polygon } from "../lib/jscad-fns/polygon"
+
+export default () => (
+  <JsCadFixture>
+    <Project axis={[0, 0, 1]} origin={[0, 0, 0]}>
+      <Polygon
+        points={[
+          [-2, -1],
+          [2, -1],
+          [2.5, 2],
+          [1, 1],
+          [0, 2],
+          [-1, 1],
+          [-2, 2],
+        ]}
+      />
+    </Project>
+  </JsCadFixture>
+);
+`;
+
+
+//rectangle
+
+export const designCodeRectangle = `
+import { Rectangle } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <Rectangle size={[10, 20]} />
+  </JsCadFixture>
+);
+`;
+
+//rotate
+
+export const designCodeRotate = `
+import { Polygon } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { Rotate } from "../lib/jscad-fns"
+
+export default () => (
+  <JsCadFixture>
+    <Rotate angles={[0, 0, Math.PI]} color="cyan" center={[0, 0, 10]}>
+      <Polygon
+        points={[
+          [-2, -1],
+          [2, -1],
+          [2.5, 2],
+          [1, 1],
+          [0, 2],
+          [-1, 1],
+          [-2, 2],
+        ]}
+      />
+    </Rotate>
+  </JsCadFixture>
+);
+`;
+
+//RoundedCuboid
+
+export const designCodeRoundedCuboid = `
+import { RoundedCuboid } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <RoundedCuboid
+      size={[15, 10, 10]}
+      roundRadius={1}
+      color="skyblue"
+      center={[0, 0, 10]}
+    />
+  </JsCadFixture>
+);
+`;
+
+//RoundedCylinder
+//from dev
+
+export const designCodeRoundedCylinder = `
+import { RoundedCylinder } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <RoundedCylinder
+      radius={10}
+      height={20}
+      roundRadius={5}
+      color="#4B0082"
+      center={[0, 0, 10]}
+    />
+  </JsCadFixture>
+);
+`;
+
+//Sphere
+
+export const designCodeSphere = `
+import { Sphere } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <Sphere radius={10} color="orange" />
+  </JsCadFixture>
+);
+`;
+
+//Subtract
+
+export const designCodeSubtract = `
+import { Cube, Sphere, Subtract } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture>
+    <Subtract>
+      <Cube size={10} />
+      <Sphere radius={6} />
+    </Subtract>
+  </JsCadFixture>
+);
+`;
+
+//torus
+
+
+export const designCodeTorus = `
+import { Torus } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <Torus innerRadius={1} outerRadius={1.2} color="red" center={[0, 10, 0]} />
+  </JsCadFixture>
+)
+;
+`;
+
+//Translate
+
+export const designCodeTranslate = `
+import { Cuboid } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+import { Translate } from "../lib/jscad-fns"
+
+export default () => (
+  <JsCadFixture>
+    <Cuboid size={[20, 10, 10]} />
+    <Cuboid center={[0, 0, 15]} size={[15, 10, 15]} color="red" />
+    <Translate offset={[0, 0, -15]}>
+      <Cuboid size={[15, 10, 15]} color="blue" />
+      <Cuboid size={[5, 25, 5]} color="white" />
+    </Translate>
+    <Translate offset={[0, 15, 0]}>
+      <Translate offset={[0, 0, -15]}>
+        <Cuboid size={[3, 3, 3]} color="green" />
+        <Cuboid size={[4, 2, 4]} color="white" />
+        <Cuboid size={[5, 1, 5]} color="red" />
+        <Translate offset={[0, 0, -10]}>
+          <Cuboid size={[3, 3, 3]} color="blue" />
+          <Cuboid size={[4, 2, 4]} color="white" />
+          <Cuboid size={[5, 1, 5]} color="red" />
+        </Translate>
+      </Translate>
+    </Translate>
+  </JsCadFixture>
+)
+;
+`;
+
+//Twisted-CylinderElliptic
+
+export const designCodeTwistedCylinderElliptic = `
+import { CylinderElliptic } from "../lib"
+import { JsCadFixture } from "../lib/components/jscad-fixture"
+
+export default () => (
+  <JsCadFixture wireframe>
+    <CylinderElliptic
+      height={6}
+      startRadius={[1, 1.5]}
+      endRadius={[1.5, 1]}
+      segments={64}
+      startAngle={0}
+      endAngle={Math.PI * 2}
+    />
+  </JsCadFixture>
+);
+`;

--- a/src/main.css
+++ b/src/main.css
@@ -3,3 +3,39 @@ body {
   margin: 0;
   padding: 0;
 }
+
+.example-container {
+  position: relative; /* This allows absolute positioning of the button and code viewer */
+}
+
+.toggle-button {
+  position: absolute;
+  top: 10px; /* Position from the top */
+  left: 10px; /* Position from the left */
+  background-color: #3b82f6; /* Blue color */
+  color: white;
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: none;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+  z-index: 10; /* Ensure the button stays above other content */
+}
+
+.toggle-button:hover {
+  background-color: #2563eb; /* Darker blue on hover */
+}
+
+.code-viewer {
+  position: absolute;
+  top: 20px;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  background-color: black;
+  padding: 16px;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  overflow-y: auto;
+  height: 40vh;
+}


### PR DESCRIPTION
#89 
/claim #89 
This PR adds a feature to the jscad-fiber usage site that allows users to view the code for each example.

I have created a user-friendly interface that is easy to use and understand. After reviewing the [Quickstart guide]
(https://docs.tscircuit.com/quickstart), I decided to adopt the same theme and organization to ensure better performance and consistency. Also I followed best practices for code quality, ensuring that it is easy to use, understand, reusable, and easily extendable for future additions.

Preview : 
![image](https://github.com/user-attachments/assets/bd1b8695-6d85-4661-b686-3f1a3f7be362)
![image](https://github.com/user-attachments/assets/d6c54116-c07b-460b-8732-7be3114d3e96)
Uploading jscad-fiber - Google Chrome 2024-11-06 13-57-57.mp4…



