### PR TITLE
Add directory prefix to example wrapper url when in GH pages

### DIFF
--- a/lib/components/Example-wrapper.tsx
+++ b/lib/components/Example-wrapper.tsx
@@ -13,7 +13,9 @@ export function ExampleWrapper({ children, fileName }: FixtureWrapperProps) {
 
   React.useEffect(() => {
     if (showCode && codeString === null) {
-      fetch(`/code-examples/${fileName}`)
+      fetch(
+        `${window.location.origin.includes("github.io") ? "/jscad-fiber" : ""}/code-examples/${fileName}`,
+      )
         .then((response) => response.text())
         .then((data) => setCodeString(data))
         .catch((error) => console.error("Error fetching code:", error))


### PR DESCRIPTION
A small follow up to #100. It turns out that Github pages require to add the directory name before the the pathname (I do get the example files when doing so in curl or in the browser), so I am adding it here.