### PR TITLE
Add manifold-3d backend via @basefold/sketch

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -5,6 +5,7 @@ import React from "react"
 export * from "./jscad-fns"
 export * from "./hooks/use-render-elements-to-jscad-plan"
 export * from "./components/jscad-view"
+export * from "./manifold"
 
 // Create a function that returns the reconciler and root creation function
 export function createJSCADRenderer(jscad: JSCADModule) {

--- a/lib/manifold/create-manifold-module.ts
+++ b/lib/manifold/create-manifold-module.ts
@@ -1,0 +1,11 @@
+/**
+ * Creates a JSCADModule-compatible adapter backed by manifold-3d via
+ * @basefold/sketch. No manifold-3d import needed — basefold-sketch
+ * handles WASM loading internally.
+ */
+
+import { createJscadModule } from "@basefold/sketch"
+
+export async function createManifoldModule() {
+  return createJscadModule()
+}

--- a/lib/manifold/index.ts
+++ b/lib/manifold/index.ts
@@ -1,0 +1,2 @@
+export { createManifoldModule } from "./create-manifold-module"
+export { BasefoldGeom3, BasefoldGeom2 } from "./manifold-geom"

--- a/lib/manifold/manifold-geom.ts
+++ b/lib/manifold/manifold-geom.ts
@@ -1,0 +1,1 @@
+export { BasefoldGeom3, BasefoldGeom2 } from "@basefold/sketch"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "format:check": "bun x biome format ."
   },
   "peerDependencies": {
+    "@basefold/sketch": "*",
     "@jscad/modeling": "*",
     "react": "19.1.0",
     "react-dom": "19.1.0",
@@ -38,6 +39,9 @@
     "three": "*"
   },
   "peerDependenciesMeta": {
+    "@basefold/sketch": {
+      "optional": true
+    },
     "@jscad/modeling": {
       "optional": true
     },
@@ -49,6 +53,7 @@
     "color": "^4.2.3"
   },
   "devDependencies": {
+    "@basefold/sketch": "file:../basefold-sketch",
     "@biomejs/biome": "^1.9.4",
     "@jscad/modeling": "^2.12.2",
     "@react-three/drei": "10.6.1",

--- a/tests/manifold/manifold-basic.test.tsx
+++ b/tests/manifold/manifold-basic.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, beforeAll } from "bun:test"
+import { createJSCADRenderer } from "../../lib"
+import { createManifoldModule } from "../../lib/manifold"
+import type { BasefoldGeom3 } from "../../lib/manifold"
+
+let manifoldModule: Awaited<ReturnType<typeof createManifoldModule>>
+
+function manifoldRender(reactNode: any) {
+  const container: any[] = []
+  const renderer = createJSCADRenderer(manifoldModule)
+  const root = renderer.createJSCADRoot(container)
+  root.render(reactNode)
+  return container
+}
+
+beforeAll(async () => {
+  manifoldModule = await createManifoldModule()
+})
+
+describe("manifold backend - primitives", () => {
+  it("should render a cube", () => {
+    const result = manifoldRender(<cube size={10} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+    expect((result[0] as BasefoldGeom3).volume()).toBeCloseTo(1000, 0)
+  })
+
+  it("should render a cuboid", () => {
+    const result = manifoldRender(<cuboid size={[10, 20, 30]} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a sphere", () => {
+    const result = manifoldRender(<sphere radius={5} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a cylinder", () => {
+    const result = manifoldRender(<cylinder radius={5} height={10} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a roundedCuboid", () => {
+    const result = manifoldRender(
+      <roundedCuboid size={[10, 10, 10]} roundRadius={1} />,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a roundedCylinder", () => {
+    const result = manifoldRender(
+      <roundedCylinder radius={5} height={10} roundRadius={1} />,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a torus", () => {
+    const result = manifoldRender(<torus innerRadius={3} outerRadius={5} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render an ellipsoid", () => {
+    const result = manifoldRender(<ellipsoid radius={[5, 3, 2]} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a geodesicSphere", () => {
+    const result = manifoldRender(<geodesicSphere radius={5} frequency={2} />)
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should render a cylinderElliptic", () => {
+    const result = manifoldRender(
+      <cylinderElliptic height={10} startRadius={[3, 5]} endRadius={[3, 5]} />,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - booleans", () => {
+  it("should union two cubes", () => {
+    const result = manifoldRender(
+      <union>
+        <cube size={10} />
+        <cube size={5} />
+      </union>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+
+  it("should subtract a sphere from a cube", () => {
+    const result = manifoldRender(
+      <subtract>
+        <cube size={10} />
+        <sphere radius={5} />
+      </subtract>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - transforms", () => {
+  it("should translate a cube", () => {
+    const result = manifoldRender(
+      <translate args={[5, 0, 0]}>
+        <cube size={10} />
+      </translate>,
+    )
+    expect(result.length).toBe(1)
+    for (const poly of result[0].polygons) {
+      for (const vert of poly.vertices) {
+        expect(vert[0]).toBeGreaterThanOrEqual(-0.01)
+      }
+    }
+  })
+
+  it("should rotate a cube", () => {
+    const result = manifoldRender(
+      <rotate angles={[0, 0, Math.PI / 4]}>
+        <cube size={10} />
+      </rotate>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - extrusions", () => {
+  it("should extrude a polygon linearly", () => {
+    const result = manifoldRender(
+      <extrudeLinear height={5}>
+        <jscadPolygon
+          points={[[-5, -5], [5, -5], [5, 5], [-5, 5]]}
+        />
+      </extrudeLinear>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - hull", () => {
+  it("should hull two cubes", () => {
+    const result = manifoldRender(
+      <hull>
+        <cube size={2} />
+        <translate args={[10, 0, 0]}>
+          <cube size={2} />
+        </translate>
+      </hull>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].polygons.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - colorize", () => {
+  it("should colorize a cube", () => {
+    const result = manifoldRender(
+      <colorize color={[1, 0, 0] as any}>
+        <cube size={10} />
+      </colorize>,
+    )
+    expect(result.length).toBe(1)
+    expect(result[0].color).toEqual([1, 0, 0])
+  })
+})
+
+describe("manifold backend - 2D shapes", () => {
+  it("should render a rectangle as 2D geometry", () => {
+    const result = manifoldRender(<rectangle size={[10, 5]} />)
+    expect(result.length).toBe(1)
+    expect(result[0].sides.length).toBeGreaterThan(0)
+  })
+
+  it("should render a circle as 2D geometry", () => {
+    const result = manifoldRender(<circle radius={5} />)
+    expect(result.length).toBe(1)
+    expect(result[0].sides.length).toBeGreaterThan(0)
+  })
+})
+
+describe("manifold backend - combined operations", () => {
+  it("should handle a complex component-like scenario", () => {
+    const result = manifoldRender(
+      <>
+        <colorize color={[0.2, 0.2, 0.2] as any}>
+          <cuboid size={[4, 2, 1]} />
+        </colorize>
+        <colorize color={[0.8, 0.8, 0.8] as any}>
+          <translate args={[-2.5, 0, 0]}>
+            <cuboid size={[1, 0.5, 0.2]} />
+          </translate>
+        </colorize>
+        <colorize color={[0.8, 0.8, 0.8] as any}>
+          <translate args={[2.5, 0, 0]}>
+            <cuboid size={[1, 0.5, 0.2]} />
+          </translate>
+        </colorize>
+      </>,
+    )
+    expect(result.length).toBe(3)
+    expect(result[0].color).toEqual([0.2, 0.2, 0.2])
+    expect(result[1].color).toEqual([0.8, 0.8, 0.8])
+  })
+})


### PR DESCRIPTION
## Summary

- Adds manifold-3d as an optional geometry backend, fully encapsulated behind **@basefold/sketch**
- Consumers depend only on @basefold/sketch — no direct manifold-3d imports needed
- `BasefoldGeom3` exposes `.volume()`, `.surfaceArea()`, `.genus()`
- Depends on [basefold-sketch#4](https://github.com/tscircuit/basefold-sketch/pull/4)

### New files
- `lib/manifold/create-manifold-module.ts` — 10-line async factory wrapping @basefold/sketch
- `lib/manifold/manifold-geom.ts` — re-exports `BasefoldGeom3`/`BasefoldGeom2`
- `lib/manifold/index.ts` — barrel export
- `tests/manifold/manifold-basic.test.tsx` — 20 tests (primitives, booleans, transforms, extrusions, hulls, colors, 2D)

### Modified files
- `lib/index.tsx` — added `export * from "./manifold"`
- `package.json` — added `@basefold/sketch` as optional peer dep + dev dep

## Test plan

- [x] `bun test` — 27 tests pass (20 manifold + 7 existing)
- [x] `bun run build` — builds successfully
- [ ] Verify no manifold-3d in package.json dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)