### PR TITLE
feat: add coordinate axis helper in bottom right corner

### DIFF
--- a/lib/components/jscad-fixture.tsx
+++ b/lib/components/jscad-fixture.tsx
@@ -7,6 +7,37 @@ import convertCSGToThreeGeom from "../../lib/convert-csg-to-three-geom"
 
 const { createJSCADRoot } = createJSCADRenderer(jscad as any)
 
+function createAxisHelper(): THREE.Group {
+  const group = new THREE.Group()
+  const length = 1
+
+  // X axis - Red
+  const xMat = new THREE.LineBasicMaterial({ color: 0xff0000 })
+  const xGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(length, 0, 0),
+  ])
+  group.add(new THREE.Line(xGeom, xMat))
+
+  // Y axis - Green
+  const yMat = new THREE.LineBasicMaterial({ color: 0x00ff00 })
+  const yGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, length, 0),
+  ])
+  group.add(new THREE.Line(yGeom, yMat))
+
+  // Z axis - Blue
+  const zMat = new THREE.LineBasicMaterial({ color: 0x0000ff })
+  const zGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 0, length),
+  ])
+  group.add(new THREE.Line(zGeom, zMat))
+
+  return group
+}
+
 export function JsCadFixture({
   children,
   wireframe,
@@ -105,6 +136,7 @@ export function JsCadFixture({
 
       const renderer = new THREE.WebGLRenderer()
       renderer.setSize(window.innerWidth, window.innerHeight)
+      renderer.autoClear = false
 
       containerRef.current.appendChild(renderer.domElement)
 
@@ -114,11 +146,51 @@ export function JsCadFixture({
       controls.dampingFactor = 0.25
       controls.enableZoom = true
 
+      // Axis helper overlay (bottom-right corner)
+      const axisScene = new THREE.Scene()
+      const axisCamera = new THREE.PerspectiveCamera(50, 1, 0.1, 10)
+      axisCamera.position.set(0, 0, 3)
+      axisCamera.lookAt(0, 0, 0)
+      const axisHelper = createAxisHelper()
+      if (zAxisUp) {
+        axisHelper.rotation.x = -Math.PI / 2
+      }
+      axisScene.add(axisHelper)
+
       // Animation loop
       function animate() {
         requestAnimationFrame(animate)
         controls.update()
+
+        // Sync axis camera orientation with main camera
+        axisCamera.quaternion.copy(camera.quaternion)
+        axisCamera.position.set(0, 0, 3).applyQuaternion(camera.quaternion)
+        axisCamera.lookAt(0, 0, 0)
+
+        renderer.clear()
         renderer.render(scene, camera)
+
+        // Render axis helper in bottom-right corner
+        const size = 100
+        const margin = 10
+        const width = renderer.domElement.width
+        const height = renderer.domElement.height
+        renderer.setViewport(
+          width - size - margin,
+          margin,
+          size,
+          size,
+        )
+        renderer.setScissor(
+          width - size - margin,
+          margin,
+          size,
+          size,
+        )
+        renderer.setScissorTest(true)
+        renderer.render(axisScene, axisCamera)
+        renderer.setScissorTest(false)
+        renderer.setViewport(0, 0, width, height)
       }
       animate()
 

--- a/lib/components/jscad-fixture.tsx
+++ b/lib/components/jscad-fixture.tsx
@@ -175,18 +175,8 @@ export function JsCadFixture({
         const margin = 10
         const width = renderer.domElement.width
         const height = renderer.domElement.height
-        renderer.setViewport(
-          width - size - margin,
-          margin,
-          size,
-          size,
-        )
-        renderer.setScissor(
-          width - size - margin,
-          margin,
-          size,
-          size,
-        )
+        renderer.setViewport(width - size - margin, margin, size, size)
+        renderer.setScissor(width - size - margin, margin, size, size)
         renderer.setScissorTest(true)
         renderer.render(axisScene, axisCamera)
         renderer.setScissorTest(false)

--- a/lib/components/jscad-view.tsx
+++ b/lib/components/jscad-view.tsx
@@ -7,6 +7,37 @@ import convertCSGToThreeGeom from "../convert-csg-to-three-geom"
 
 const { createJSCADRoot } = createJSCADRenderer(jscad as any)
 
+function createAxisHelper(): THREE.Group {
+  const group = new THREE.Group()
+  const length = 1
+
+  // X axis - Red
+  const xMat = new THREE.LineBasicMaterial({ color: 0xff0000 })
+  const xGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(length, 0, 0),
+  ])
+  group.add(new THREE.Line(xGeom, xMat))
+
+  // Y axis - Green
+  const yMat = new THREE.LineBasicMaterial({ color: 0x00ff00 })
+  const yGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, length, 0),
+  ])
+  group.add(new THREE.Line(yGeom, yMat))
+
+  // Z axis - Blue
+  const zMat = new THREE.LineBasicMaterial({ color: 0x0000ff })
+  const zGeom = new THREE.BufferGeometry().setFromPoints([
+    new THREE.Vector3(0, 0, 0),
+    new THREE.Vector3(0, 0, length),
+  ])
+  group.add(new THREE.Line(zGeom, zMat))
+
+  return group
+}
+
 export function JsCadView({
   children,
   wireframe,
@@ -105,6 +136,7 @@ export function JsCadView({
 
       const renderer = new THREE.WebGLRenderer()
       renderer.setSize(window.innerWidth, window.innerHeight)
+      renderer.autoClear = false
 
       containerRef.current.appendChild(renderer.domElement)
 
@@ -114,11 +146,51 @@ export function JsCadView({
       controls.dampingFactor = 0.25
       controls.enableZoom = true
 
+      // Axis helper overlay (bottom-right corner)
+      const axisScene = new THREE.Scene()
+      const axisCamera = new THREE.PerspectiveCamera(50, 1, 0.1, 10)
+      axisCamera.position.set(0, 0, 3)
+      axisCamera.lookAt(0, 0, 0)
+      const axisHelper = createAxisHelper()
+      if (zAxisUp) {
+        axisHelper.rotation.x = -Math.PI / 2
+      }
+      axisScene.add(axisHelper)
+
       // Animation loop
       function animate() {
         requestAnimationFrame(animate)
         controls.update()
+
+        // Sync axis camera orientation with main camera
+        axisCamera.quaternion.copy(camera.quaternion)
+        axisCamera.position.set(0, 0, 3).applyQuaternion(camera.quaternion)
+        axisCamera.lookAt(0, 0, 0)
+
+        renderer.clear()
         renderer.render(scene, camera)
+
+        // Render axis helper in bottom-right corner
+        const size = 100
+        const margin = 10
+        const width = renderer.domElement.width
+        const height = renderer.domElement.height
+        renderer.setViewport(
+          width - size - margin,
+          margin,
+          size,
+          size,
+        )
+        renderer.setScissor(
+          width - size - margin,
+          margin,
+          size,
+          size,
+        )
+        renderer.setScissorTest(true)
+        renderer.render(axisScene, axisCamera)
+        renderer.setScissorTest(false)
+        renderer.setViewport(0, 0, width, height)
       }
       animate()
 

--- a/lib/components/jscad-view.tsx
+++ b/lib/components/jscad-view.tsx
@@ -175,18 +175,8 @@ export function JsCadView({
         const margin = 10
         const width = renderer.domElement.width
         const height = renderer.domElement.height
-        renderer.setViewport(
-          width - size - margin,
-          margin,
-          size,
-          size,
-        )
-        renderer.setScissor(
-          width - size - margin,
-          margin,
-          size,
-          size,
-        )
+        renderer.setViewport(width - size - margin, margin, size, size)
+        renderer.setScissor(width - size - margin, margin, size, size)
         renderer.setScissorTest(true)
         renderer.render(axisScene, axisCamera)
         renderer.setScissorTest(false)


### PR DESCRIPTION
## Summary

Closes #79

Adds a coordinate axis helper (X/Y/Z direction indicator) rendered as an overlay in the bottom-right corner of both `JscadFixture` and `JscadView` components.

## Changes

- Added `createAxisHelper()` utility that creates colored axis lines (Red=X, Green=Y, Blue=Z)
- Added a secondary scene + camera for the axis overlay, rendered via viewport/scissor
- The axis helper rotates in sync with the main camera orientation
- Respects `zAxisUp` prop (rotates axis helper accordingly)
- Overlay size: 100×100px with 10px margin from bottom-right corner

## Implementation

Uses Three.js viewport/scissor rendering to draw the axis helper as an inset overlay without affecting the main scene. The axis camera quaternion is synced with the main camera each frame so the helper always reflects the current viewing angle.

/claim #79